### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+
+install:
+  - pip install -U pip
+  - make install
+
+script:
+  - make test


### PR DESCRIPTION
This PR introduces a `.travis.yml` for use with buildbot-travis.